### PR TITLE
プチプチノイズ低減対策

### DIFF
--- a/Source/process/FFTFilter.cpp
+++ b/Source/process/FFTFilter.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<float> FFTFilter::getSpectrumOutput(void)
 void FFTFilter::filter_process(float* in_data, float* out_data, int size, int side)
 {
 	{
-		window.multiplyWithWindowingTable(in_data, size);
+		//window.multiplyWithWindowingTable(in_data, size);
 		// store input for spectrum
 		for (int i = 0; i < size; i++) {
 			fftIn.getData()[i].real(in_data[i]);

--- a/Source/process/FFTFilter.h
+++ b/Source/process/FFTFilter.h
@@ -23,8 +23,8 @@ protected:
 	std::shared_ptr<float> fftbuf_in, fftbuf_out;
 private:
 	/* --- method*/
-	void filter_process(float *in_data, float *out_data, int size, int side) override;
-	virtual void effect(const juce::HeapBlock<juce::dsp::Complex<float>> &in_data, juce::HeapBlock<juce::dsp::Complex<float>> &out_data, int size, int side);
+	void filter_process(float* in_data, float* out_data, int size, int side) override;
+	virtual void effect(const juce::HeapBlock<juce::dsp::Complex<float>>& in_data, juce::HeapBlock<juce::dsp::Complex<float>>& out_data, int size, int side);
 	/* --- member */
 	std::shared_ptr<float> level;
 	juce::dsp::FFT forwardFFT;

--- a/Source/process/FilterBase.cpp
+++ b/Source/process/FilterBase.cpp
@@ -9,6 +9,7 @@ FilterBase::FilterBase(int segment_length, int buffer_length) :
 {
 	input_buffer[0] = new float[segment_length];
 	input_buffer[1] = new float[segment_length];
+	input_buffer[2] = new float[segment_length];
 	output_buffer[0] = new float[buffer_length];
 	output_buffer[1] = new float[buffer_length];
 	filter_buffer[0] = new float[segment_length];
@@ -19,6 +20,7 @@ FilterBase::~FilterBase()
 {
 	delete[] input_buffer[0];
 	delete[] input_buffer[1];
+	delete[] input_buffer[2];
 	delete[] output_buffer[0];
 	delete[] output_buffer[1];
 	delete[] filter_buffer[0];
@@ -46,9 +48,30 @@ void FilterBase::process(float* buffer_1, float* buffer_2, int size)
 		if (input_pointer == 0) {
 			filter_process(input_buffer[0], filter_buffer[0], segment_length, 0);
 			filter_process(input_buffer[1], filter_buffer[1], segment_length, 1);
+			int offset = segment_length / 4;
+			for (size_t i = 0; i < segment_length / 2; i++) {
+				output_buffer[0][output_buffer_pointer] = filter_buffer[0][i + offset];
+				output_buffer[1][output_buffer_pointer] = filter_buffer[1][i + offset];
+				output_buffer_pointer = (output_buffer_pointer + 1) % buffer_length;
+			}
+			setProcessFlag(true);
+		}
+		else if (input_pointer == segment_length / 2) {
+			int shift = segment_length / 2 + 1;
 			for (size_t i = 0; i < segment_length; i++) {
-				output_buffer[0][output_buffer_pointer] = filter_buffer[0][i];
-				output_buffer[1][output_buffer_pointer] = filter_buffer[1][i];
+				input_buffer[2][i] = input_buffer[0][shift];
+				shift = (shift + 1) % segment_length;
+			}
+			filter_process(input_buffer[2], filter_buffer[0], segment_length, 0);
+			for (size_t i = 0; i < segment_length; i++) {
+				input_buffer[2][i] = input_buffer[1][shift];
+				shift = (shift + 1) % segment_length;
+			}
+			filter_process(input_buffer[2], filter_buffer[1], segment_length, 1);
+			int offset = segment_length / 4;
+			for (size_t i = 0; i < segment_length / 2; i++) {
+				output_buffer[0][output_buffer_pointer] = filter_buffer[0][i + offset];
+				output_buffer[1][output_buffer_pointer] = filter_buffer[1][i + offset];
 				output_buffer_pointer = (output_buffer_pointer + 1) % buffer_length;
 			}
 			setProcessFlag(true);
@@ -74,7 +97,7 @@ int FilterBase::output(float* buffer_1, float* buffer_2, int size)
 	return size;
 }
 
-void FilterBase::filter_process(float *in_data, float *out_data, int size, int side)
+void FilterBase::filter_process(float* in_data, float* out_data, int size, int side)
 {
 	// sample: copy only
 	for (int i = 0; i < size; i++) {

--- a/Source/process/FilterBase.h
+++ b/Source/process/FilterBase.h
@@ -10,8 +10,8 @@ public:
 	virtual ~FilterBase();
 
 	/* --- method*/
-	void process(float *buffer_1, float *buffer_2, int size);
-	int output(float* buffer_1, float *buffer_2, int size);
+	void process(float* buffer_1, float* buffer_2, int size);
+	int output(float* buffer_1, float* buffer_2, int size);
 	void setProcessFlag(bool flag);
 	bool getProcessFlag();
 	/* --- member */
@@ -24,11 +24,11 @@ protected:
 	int buffer_length;
 private:
 	/* --- method*/
-	virtual void filter_process(float *in_data, float *out_data, int size, int side);
+	virtual void filter_process(float* in_data, float* out_data, int size, int side);
 	/* --- member */
-	float *input_buffer[2];
-	float *output_buffer[2];
-	float *filter_buffer[2];
+	float* input_buffer[3];
+	float* output_buffer[2];
+	float* filter_buffer[2];
 	int input_pointer;
 	int output_buffer_pointer;
 	int output_pointer;

--- a/Source/process/PitchFilter.cpp
+++ b/Source/process/PitchFilter.cpp
@@ -23,15 +23,10 @@ PitchFilter::PitchFilter(int segment_length, int buffer_length) :
 	for (auto i = 0; i < base_analyzer_filter_size; i++) {
 		base_freq_filter[i] = 80.0f;
 	}
-	logger = juce::FileLogger::createDefaultAppLogger("logs", "uchinoko_voice.log", "start", 65536000);
-	juce::Logger::setCurrentLogger(logger);
-	juce::Logger::writeToLog("====== test");
 }
 
 PitchFilter::~PitchFilter()
 {
-	juce::Logger::setCurrentLogger(nullptr);
-	delete logger;
 }
 
 void PitchFilter::setFrequencyShift(float pitch, float if_samplerate)
@@ -174,13 +169,6 @@ void PitchFilter::update_table()
 	// update pitch table
 	// -----------------------------
 	{
-#if 0
-		char line[500];
-		for (auto i = 0; i < fft_size; i++) {
-			sprintf_s(line, "%4d = %4d", i, formant_table.get()[i]);
-			juce::Logger::writeToLog(std::string(line));
-		}
-#endif
 		std::lock_guard<std::mutex> lock(flag_lock);
 		for (auto i = 0; i < fft_size; i++) {
 			pitch_table.get()[i] = formant_table.get()[i];

--- a/Source/process/PitchFilter.cpp
+++ b/Source/process/PitchFilter.cpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "PitchFilter.h"
 
+
 PitchFilter::PitchFilter(int segment_length, int buffer_length) :
 	FFTFilter(segment_length, buffer_length)
 	, pitch_table(new int[segment_length])
@@ -22,10 +23,15 @@ PitchFilter::PitchFilter(int segment_length, int buffer_length) :
 	for (auto i = 0; i < base_analyzer_filter_size; i++) {
 		base_freq_filter[i] = 80.0f;
 	}
+	logger = juce::FileLogger::createDefaultAppLogger("logs", "uchinoko_voice.log", "start", 65536000);
+	juce::Logger::setCurrentLogger(logger);
+	juce::Logger::writeToLog("====== test");
 }
 
 PitchFilter::~PitchFilter()
 {
+	juce::Logger::setCurrentLogger(nullptr);
+	delete logger;
 }
 
 void PitchFilter::setFrequencyShift(float pitch, float if_samplerate)
@@ -96,6 +102,9 @@ void PitchFilter::update_table()
 		if (((step_fq * i) < shift_pitch) && (i > 0)) {
 			shift_table.get()[i] = -1;
 		}
+		else if (((i % 2) == 0) && (index == 1)) {
+			shift_table.get()[i] = -1;
+		}
 		else {
 			shift_table.get()[i] = index;
 			index++;
@@ -127,13 +136,18 @@ void PitchFilter::update_table()
 			}
 			else if (fq < (sample_rate / 2.0)) {
 				int new_index = (int)(fq / step_fq);
-				if (new_index != post_index) {
-					formant_table.get()[i] = shift_table.get()[new_index];
-					post_index = new_index;
+				//if (new_index != post_index) {
+				if ((i % 2) != (new_index % 2)) {
+					//formant_table.get()[i] = -1;
+					//continue;
+					new_index += 1;
 				}
-				else {
-					formant_table.get()[i] = -1;
-				}
+				formant_table.get()[i] = shift_table.get()[new_index];
+				post_index = new_index;
+				//}
+				//else {
+				//	formant_table.get()[i] = -1;
+				//}
 				fq += step_shift;
 			}
 			else {
@@ -160,6 +174,13 @@ void PitchFilter::update_table()
 	// update pitch table
 	// -----------------------------
 	{
+#if 0
+		char line[500];
+		for (auto i = 0; i < fft_size; i++) {
+			sprintf_s(line, "%4d = %4d", i, formant_table.get()[i]);
+			juce::Logger::writeToLog(std::string(line));
+		}
+#endif
 		std::lock_guard<std::mutex> lock(flag_lock);
 		for (auto i = 0; i < fft_size; i++) {
 			pitch_table.get()[i] = formant_table.get()[i];
@@ -184,9 +205,9 @@ float PitchFilter::analyze_basefreq()
 	}
 	if (peak > 0) {
 		auto freq1 = (peak) * ((sample_rate / 2.0) / (segment_length / 2.0));
-		auto freq2 = (peak+1) * ((sample_rate / 2.0) / (segment_length / 2.0));
+		auto freq2 = (peak + 1) * ((sample_rate / 2.0) / (segment_length / 2.0));
 		auto pow1 = fftbuf_in.get()[peak];
-		auto pow2 = fftbuf_in.get()[peak+1];
+		auto pow2 = fftbuf_in.get()[peak + 1];
 		freq = (float)((freq1 * pow1 + freq2 * pow2) / ((double)pow1 + (double)pow2));
 		freq = juce::jmax(freq, 60.0f);
 	}
@@ -208,14 +229,16 @@ void PitchFilter::effect(const juce::HeapBlock<juce::dsp::Complex<float>>& in_da
 	{
 		std::lock_guard<std::mutex> lock(flag_lock);
 		// pitch shifting
+		int target;
 		for (int i = 0; i < size; i++) {
 			if (pitch_table.get()[i] < 0) {
 				out_data.get()[i].real(0);
 				out_data.get()[i].imag(0);
 			}
 			else {
-				out_data.get()[i].real(in_data.get()[pitch_table.get()[i]].real());
-				out_data.get()[i].imag(in_data.get()[pitch_table.get()[i]].imag());
+				target = pitch_table.get()[i];
+				out_data.get()[i].real(in_data.get()[target].real());
+				out_data.get()[i].imag(in_data.get()[target].imag());
 			}
 		}
 	}

--- a/Source/process/PitchFilter.h
+++ b/Source/process/PitchFilter.h
@@ -4,7 +4,7 @@
 #include <JuceHeader.h>
 
 class PitchFilter :
-    public FFTFilter
+	public FFTFilter
 {
 public:
 	PitchFilter(int segment_length, int buffer_length);
@@ -41,5 +41,6 @@ private:
 	int base_freq_filter_count;
 	float base_freq_filter[16];
 
+	juce::FileLogger* logger;
 };
 

--- a/Source/process/PitchFilter.h
+++ b/Source/process/PitchFilter.h
@@ -40,7 +40,5 @@ private:
 	const int base_analyzer_filter_size = 16;
 	int base_freq_filter_count;
 	float base_freq_filter[16];
-
-	juce::FileLogger* logger;
 };
 


### PR DESCRIPTION
- FFT 変換作業を倍の数にして、結果の中央部だけオーバーラップする形で取り出すようにした
- FFT 逆変換テーブルで奇数値だけずれるとプチノイズになるので、偶数単位で変化させるようにした
